### PR TITLE
Adding RevenueCat blog

### DIFF
--- a/content.json
+++ b/content.json
@@ -1377,6 +1377,13 @@
             "twitter_url": "https://twitter.com/reveal_app"
           },
           {
+            "title": "RevenueCat Blog",
+            "author": "Jacob Eiting",
+            "site_url": "https://medium.com/revenuecat-blog",
+            "feed_url": "https://medium.com/feed/revenuecat-blog",
+            "twitter_url": "https://twitter.com/jeiting"
+          },
+          {
             "title": "Roundwall Software",
             "author": "Samuel Goodwin",
             "site_url": "https://roundwallsoftware.com",


### PR DESCRIPTION
Hey Dave!

Totally self serving PR here. Thought I'd add the [RevenueCat blog](https://medium.com/revenuecat-blog). It's all iOS, all the time.

Thanks for putting this together! 