### PR TITLE
 Add NSProgrammer to iOS Dev Blogs

### DIFF
--- a/content.json
+++ b/content.json
@@ -1605,13 +1605,6 @@
             "feed_url": "https://itunes.apple.com/gb/podcast/the-ideveloper-podcast/id400664935?mt=2"
           },
           {
-            "title": "iOhYes",
-            "author": "John Sextro and Darryl Thomas",
-            "site_url": "http://5by5.tv/iohyes",
-            "feed_url": "http://feeds.5by5.tv/iohyes",
-            "twitter_url": "https://twitter.com/iOhYesPodcast"
-          },
-          {
             "title": "Inside iOS Dev",
             "author": "Andrew Rohn, Alex Bush",
             "site_url": "http://insideiosdev.com",

--- a/content.json
+++ b/content.json
@@ -1612,6 +1612,13 @@
             "feed_url": "https://itunes.apple.com/gb/podcast/the-ideveloper-podcast/id400664935?mt=2"
           },
           {
+            "title": "iOhYes",
+            "author": "John Sextro and Darryl Thomas",
+            "site_url": "http://5by5.tv/iohyes",
+            "feed_url": "http://feeds.5by5.tv/iohyes",
+            "twitter_url": "https://twitter.com/iOhYesPodcast"
+          },
+          {
             "title": "Inside iOS Dev",
             "author": "Andrew Rohn, Alex Bush",
             "site_url": "http://insideiosdev.com",

--- a/content.json
+++ b/content.json
@@ -793,13 +793,6 @@
             "twitter_url": "https://twitter.com/mikeash"
           },
           {
-            "title": "NSProgrammer",
-            "author": "Nolan O'Brien",
-            "site_url": "http://nsprogrammer.com",
-            "feed_url": "http://www.nsprogrammer.com/feeds/posts/default",
-            "twitter_url": "https://twitter.com/NSProgrammer"
-          },
-          {
             "title": "Objective-See's Blog",
             "author": "Patrick Wardle",
             "site_url": "https://www.objective-see.com/blog.html",
@@ -1893,6 +1886,13 @@
             "site_url": "http://nshipster.com",
             "feed_url": "http://nshipster.com/feed.xml",
             "twitter_url": "https://twitter.com/nshipster"
+          },
+          {
+            "title": "NSProgrammer",
+            "author": "Nolan O'Brien",
+            "site_url": "http://nsprogrammer.com",
+            "feed_url": "http://www.nsprogrammer.com/feeds/posts/default",
+            "twitter_url": "https://twitter.com/NSProgrammer"
           },
           {
             "title": "that thing in swift",


### PR DESCRIPTION
Add NSProgrammer.com to the list of iOS Development Blogs