### PR TITLE
add traditional chinese & one zh-tw blog

### DIFF
--- a/content.json
+++ b/content.json
@@ -2273,9 +2273,9 @@
                 {
                     "title": "鍵盤藍綠藻Neo",
                     "author": "ShihTing Huang",
-                    "site_url": "https://pilgwon.github.io/blog/",
-                    "feed_url": "https://pilgwon.github.io/blog/feed.xml",
-                    "twitter_url": "https://twitter.com/pilgwon"
+                    "site_url": "https://koromiko1104.wordpress.com/",
+                    "feed_url": "https://koromiko1104.wordpress.com/comments/feed/",
+                    "twitter_url": "https://twitter.com/KoromikoNeo"
                 }
             ]
         }

--- a/content.json
+++ b/content.json
@@ -2210,12 +2210,12 @@
                 {
                     "title": "鍵盤藍綠藻Neo",
                     "author": "ShihTing Huang",
-                    "site_url": "https://koromiko1104.wordpress.com/",
-                    "feed_url": "https://koromiko1104.wordpress.com/feed/",
-                    "twitter_url": "https://twitter.com/KoromikoNeo"
+                    "site_url": "https://pilgwon.github.io/blog/",
+                    "feed_url": "https://pilgwon.github.io/blog/feed.xml",
+                    "twitter_url": "https://twitter.com/pilgwon"
                 }
             ]
         }
     ]
-},
+  }
 ]

--- a/content.json
+++ b/content.json
@@ -2197,5 +2197,25 @@
         ]
       }
     ]
-  }
+  },
+  {
+    "language": "zh-tw",
+    "title": "Traditional Chinese Language",
+    "categories": [
+        {
+            "title": "正體中文iOS部落格",
+            "slug": "開發",
+            "description": "來自台灣的Swift、Objective-C開發者，我們討論架構、語法、應用、與任何跟iOS開發相關的主題",
+            "sites": [
+                {
+                    "title": "鍵盤藍綠藻Neo",
+                    "author": "ShihTing Huang",
+                    "site_url": "https://koromiko1104.wordpress.com/",
+                    "feed_url": "https://koromiko1104.wordpress.com/feed/",
+                    "twitter_url": "https://twitter.com/KoromikoNeo"
+                }
+            ]
+        }
+    ]
+},
 ]


### PR DESCRIPTION
Add a Traditional Chinese category to support Taiwan's contents.   