### PR TITLE
Add SwiftLee blog to content.json

### DIFF
--- a/content.json
+++ b/content.json
@@ -1209,6 +1209,13 @@
             "twitter_url": "https://twitter.com/gregheo"
           },
           {
+            "title": "Swiftlee",
+            "author": "Antoine van der Lee",
+            "site_url": "https://www.avanderlee.com",
+            "feed_url": "https://www.avanderlee.com/feed/",
+            "twitter_url": "https://twitter.com/twannl"
+          },
+          {
             "title": "swifting.io",
             "author": "Michał Wojtysiak, Bartłomiej Woronin and Maciej Piotrowski",
             "site_url": "https://swifting.io",


### PR DESCRIPTION
This adds the _Swiftlee_ blog to the `content.json`. This blog is also known as _Antoine van der Lee's blog_ and is recently updated with a [fresh design](https://twitter.com/twannl/status/997492006472507394).

Check it out yourself here: [avanderlee.com](https://www.avanderlee.com)