### PR TITLE
Update Kitefaster blog links to point to iOS content

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2039,8 +2039,8 @@
           {
             "title": "Kitefaster's iOS Development Blog",
             "author": "Kitefaster",
-            "site_url": "https://kitefaster.com/posts/",
-            "feed_url": "https://kitefaster.com/posts/index.xml",
+            "site_url": "https://kitefaster.com/categories/ios-development/",
+            "feed_url": "https://kitefaster.com/categories/ios-development/index.xml",
             "twitter_url": "https://twitter.com/kitefasterapps"
           },
           {


### PR DESCRIPTION
Here you go.  I switch content management platforms and am still getting used to all of the features.