### PR TITLE
Update URL to the iOS section of my blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1017,7 +1017,7 @@
           {
             "title": "Lord Codes",
             "author": "Andrew Lord",
-            "site_url": "https://www.lordcodes.com/categories/ios-swift/",
+            "site_url": "https://www.lordcodes.com/ios/",
             "feed_url": "https://www.lordcodes.com/feeds/ios.xml",
             "twitter_url": "https://twitter.com/lordcodes"
           },


### PR DESCRIPTION
The previous URL still works (with redirect), but updating to the up-to-date URL.