### PR TITLE
Add Swift and Pizza blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2166,6 +2166,13 @@
             "twitter_url": "https://twitter.com/swiftpainless"
           },
           {
+            "title": "Swift And Pizza",
+            "author": "Daniele Bogo",
+            "site_url": "https://swiftandpizza.com/",
+            "feed_url": "http://swiftandpizza.com/feed",
+            "twitter_url": "https://twitter.com/theillbo"
+          },
+          {
             "title": "Swift by Sundell",
             "author": "John Sundell",
             "site_url": "https://www.swiftbysundell.com/",


### PR DESCRIPTION
This PR adds [Swift and Pizza](https://swiftandpizza.com/) in the blogs