### PR TITLE
Updated RevenueCat

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3493,9 +3493,9 @@
           {
             "title": "RevenueCat Blog",
             "author": "Jacob Eiting",
-            "site_url": "https://medium.com/revenuecat-blog",
-            "feed_url": "https://medium.com/feed/revenuecat-blog",
-            "twitter_url": "https://twitter.com/jeiting"
+            "site_url": "https://www.revenuecat.com/blog",
+            "feed_url": "https://www.revenuecat.com/blog/rss.xml",
+            "twitter_url": "https://twitter.com/revenuecat"
           },
           {
             "title": "Rightpoint Labs Blog",


### PR DESCRIPTION
We moved away from Medium in the fall and finally added RSS to the site earlier this year.