### PR TITLE
Register The Imaginary Road in the blog list

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3347,6 +3347,13 @@
             "twitter_url": "https://twitter.com/nickoneill"
           },
           {
+            "title": "The Imaginary Road",
+            "author": "Michael Collins",
+            "site_url": "https://www.michaelfcollins3.me/categories/ios-development/",
+            "feed_url": "https://www.michaelfcollins3.me/categories/ios-development/index.xml",
+            "twitter_url": "https://twitter.com/mfcollins3"
+          },
+          {
             "title": "Theocacao",
             "author": "Scott Stevenson",
             "site_url": "http://theocacao.com",


### PR DESCRIPTION
I added a new entry to blogs.json to show my blog, The Imaginary Road,
in the list. I linked to my category on iOS Development.