### PR TITLE
Updated Advanced Swift

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -141,8 +141,8 @@
           {
             "title": "Advanced Swift",
             "author": "Robert Pieta",
-            "site_url": "https://www.robertpieta.com/",
-            "feed_url": "https://www.robertpieta.com/rss",
+            "site_url": "https://www.advancedswift.com/",
+            "feed_url": "https://www.advancedswift.com/rss",
             "twitter_url": "https://twitter.com/robertpieta"
           },
           {


### PR DESCRIPTION
New domain, [robertpieta.com](https://www.robertpieta.com) -> [advancedswift.com](https://www.advancedswift.com)