### PR TITLE
Fix case insensitive site_url

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1316,7 +1316,7 @@
           {
             "title": "Felizia Bernutz's Blog",
             "author": "Felizia Bernutz",
-            "site_url": "https://fbernutz.github.io/iOS/",
+            "site_url": "https://fbernutz.github.io/ios/",
             "feed_url": "https://fbernutz.github.io/feed.rss",
             "twitter_url": "https://twitter.com/felibe444"
           },


### PR DESCRIPTION
Sorry for the inconvenience, but I had some case insensitive issues with GitHub Pages. The new URL should now work.