### PR TITLE
Edited blogs file to update information regarding Fireside Swift hosts

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4952,7 +4952,7 @@
           },
           {
             "title": "Fireside Swift",
-            "author": "Zack and Steven Berard",
+            "author": "Steven Berard, Ben Sullivan, Chris Hefferman, Jordan Muncrief",
             "site_url": "https://www.firesideswift.com",
             "twitter_url": "https://twitter.com/fireside_swift",
             "feed_url": "https://www.firesideswift.com/episodes?format=RSS"


### PR DESCRIPTION
Noticed that the Fireside Swift podcast needed the host section updated.