### PR TITLE
Update loopwerk.io feed

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2278,8 +2278,8 @@
           {
             "title": "Loopwerk.io",
             "author": "Kevin Renskers",
-            "site_url": "https://loopwerk.io/",
-            "feed_url": "https://loopwerk.io/articles/feed.xml",
+            "site_url": "https://www.loopwerk.io/",
+            "feed_url": "https://www.loopwerk.io/articles/tag/swift/feed.xml",
             "twitter_url": "https://twitter.com/kevinrenskers"
           },
           {


### PR DESCRIPTION
I now have a feed per category, which prevents non-Swift articles from showing up.