### PR TITLE
Moved cutecoder.org to indiespark.top

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3957,10 +3957,10 @@
             "twitter_url": "https://twitter.com/_vojto"
           },
           {
-            "title": "Walled Garden Farmers",
+            "title": "Indie Spark",
             "author": "Sasmito Adibowo",
-            "site_url": "https://cutecoder.org/category/programming/",
-            "feed_url": "https://cutecoder.org/category/programming/feed/"
+            "site_url": "https://indiespark.top/category/programming/",
+            "feed_url": "https://indiespark.top/category/programming/feed/"
           },
           {
             "title": "Warp your mobile development",
@@ -4329,10 +4329,10 @@
             "twitter_url": "https://twitter.com/Vini__leal"
           },
           {
-            "title": "Walled Garden Farmers",
+            "title": "Indie Spark",
             "author": "Sasmito Adibowo",
-            "site_url": "https://cutecoder.org/category/business/",
-            "feed_url": "https://cutecoder.org/category/business/feed/",
+            "site_url": "https://indiespark.top/category/business/",
+            "feed_url": "https://indiespark.top/category/business/feed/",
             "twitter_url": "https://twitter.com/cutecoder"
           },
           {

--- a/blogs.json
+++ b/blogs.json
@@ -3959,8 +3959,8 @@
           {
             "title": "Indie Spark",
             "author": "Sasmito Adibowo",
-            "site_url": "https://indiespark.top/category/programming/",
-            "feed_url": "https://indiespark.top/category/programming/feed/"
+            "site_url": "https://indiespark.top/tag/ios/",
+            "feed_url": "https://indiespark.top/tag/ios/feed/"
           },
           {
             "title": "Warp your mobile development",
@@ -4331,8 +4331,8 @@
           {
             "title": "Indie Spark",
             "author": "Sasmito Adibowo",
-            "site_url": "https://indiespark.top/category/business/",
-            "feed_url": "https://indiespark.top/category/business/feed/",
+            "site_url": "https://indiespark.top/tag/app-store/",
+            "feed_url": "https://indiespark.top/tag/app-store/feed/",
             "twitter_url": "https://twitter.com/cutecoder"
           },
           {


### PR DESCRIPTION
## Changed

 - Moved `cutecoder.org` to `indiespark.top`
 - Use tag-based link to be more focused on iOS
