### PR TITLE
fix cossack labs' blog link

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4559,8 +4559,8 @@
           {
             "title": "Cossack Labs Blog",
             "author": "Cossack Labs",
-            "site_url": "https://www.cossacklabs.com/tags/iOS/",
-            "feed_url": "https://www.cossacklabs.com/feeds/all.rss.xml",
+            "site_url": "https://www.cossacklabs.com/tags/mobile/",
+            "feed_url": "https://www.cossacklabs.com/blog/index.xml",
             "twitter_url": "https://twitter.com/cossacklabs"
           },
           {


### PR DESCRIPTION
re #593 — i am just updating the links.

i think we've stopped using "ios" tag in 2019 and switched to "mobile" (still mostly iOS, don't ask why..).

also, i updated rss link.

@daveverwer does it make sense?