### PR TITLE
replace twitter_url for Harshil Shah’s Blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1628,7 +1628,7 @@
             "author": "Harshil Shah",
             "site_url": "https://harshil.net/",
             "feed_url": "https://harshil.net/feed.xml",
-            "twitter_url": "https://twitter.com/_HarshilShah"
+            "twitter_url": "https://twitter.com/Harshil"
           },
           {
             "title": "Heberti Almeida’s Blog",


### PR DESCRIPTION
current url https://twitter.com/_harshilshah
leads to an protected account and its description
states "You're looking for @Harshil"

<img width="642" alt="Screen Shot 2022-02-11 at 12 02 39 PM" src="https://user-images.githubusercontent.com/4176826/153662470-6192e51c-d42c-4adb-b2d3-81c7c0dbf98a.png">

https://twitter.com/Harshil actually has a public
twitter profile with 4k followers

<img width="484" alt="Screen Shot 2022-02-11 at 12 06 42 PM" src="https://user-images.githubusercontent.com/4176826/153662542-902318f7-c83a-45bf-ac1a-4d17bec8fe14.png">

