### PR TITLE
Adding Indie Watch

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5529,6 +5529,13 @@
             "site_url": "https://uidesignerweekly.curated.co",
             "feed_url": "https://uidesignerweekly.curated.co/issues.rss",
             "twitter_url": "https://twitter.com/sahandnayebaziz"
+          },
+          {
+            "title": "Indie Watch",
+            "author": "Aryaman Sharda",
+            "site_url": "http://indie.watch/",
+            "feed_url": "http://indie.watch/rss",
+            "twitter_url": "https://twitter.com/aryamansharda"
           }
         ]
       },


### PR DESCRIPTION
Hey Dave, you've shared a few of my articles on https://digitalbunker.dev/ previously and was hoping you'd consider adding my latest project to your directory.

Indie Watch is a weekly newsletter showcasing the best indie-iOS apps from developers worldwide. Each issue highlights an indie app and its creator.

It provides actionable advice for other indie iOS developers and helps level the marketing playing field for indie developers.