### PR TITLE
Add yono.ai to list of blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4290,6 +4290,13 @@
             "twitter_url": "https://twitter.com/yonaskolb"
           },
           {
+            "title": "Yono Mittlefehldt’s Blog",
+            "author": "Yono Mittlefehldt",
+            "site_url": "https://yono.ai/",
+            "feed_url": "https://yono.ai/feed.rss",
+            "twitter_url": "https://twitter.com/yonomitt"
+          },
+          {
             "title": "YoSwift",
             "author": "Manoj Karki",
             "site_url": "https://yoswift.dev",


### PR DESCRIPTION
This PR adds my blog, [yono.ai](https://yono.ai), to the development category of the blogs JSON