### PR TITLE
Adding gSkinner and Flutter to company blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4705,6 +4705,20 @@
         "description": "If a blog is published by a company rather than an individual (or group) of individuals, but is still related to Apple platform development. This is where you’ll find it!",
         "sites": [
           {
+            "title": "Flutter Medium",
+            "author": "Flutter Team",
+            "site_url": "https://medium.com/flutter",
+            "feed_url": "https://medium.com/feed/flutter",
+            "twitter_url": "https://twitter.com/flutterdev"
+          },
+          {
+            "title": "gSkinner Blog",
+            "author": "gSkinner",
+            "site_url": "https://www.gskinner.com/blog/",
+            "feed_url": "https://www.gskinner.com/blog/feed/",
+            "twitter_url": "https://twitter.com/gskinner_team"          
+          },
+          {
             "title": "47 Degrees Blog",
             "author": "47 Degrees",
             "site_url": "https://www.47deg.com/blog/",


### PR DESCRIPTION
I am suggesting adding gSkinner (dev/design agency) and Flutter blog feeds. 

gSkinner has created beautiful iOS apps, and Flutter is a great choice for cross-platform apps.