### PR TITLE
Add workflow to check for 301 or 302 redirects in blogs.json 

### DIFF
--- a/.github/check_for_changes.sh
+++ b/.github/check_for_changes.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+diff --brief blogs.json new_blogs.json >/dev/null
+CONTAINS_CHANGES=$?
+
+if [ $CONTAINS_CHANGES -eq 1 ]; then
+    echo "changes=true" >> $GITHUB_OUTPUT
+else
+    echo "changes=false" >> $GITHUB_OUTPUT
+fi

--- a/.github/workflows/url-scanner.yml
+++ b/.github/workflows/url-scanner.yml
@@ -1,0 +1,39 @@
+name: URL Scanner
+
+on:
+  schedule:
+    - cron:  '0 4 * * 2'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Validate URLs
+        uses: mathiasvr/command-output@v2.0.0
+        id: mutate
+        with:
+          run: bundle exec rake validate:urls
+      - name: Check for Changes
+        run: bash .github/check_for_changes.sh
+        id: check
+      - name: Replace blogs.json
+        if: steps.check.outputs.changes == 'true'
+        run: mv new_blogs.json blogs.json
+      - name: Create Pull Request
+        id: cpr
+        if: steps.check.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: |
+            blogs.json
+          commit-message: "Weekly URL cleanup automation"
+          title: "Weekly URL cleanup automation"
+          branch: spi-auto-${{ github.run_id }}
+          delete-branch: true
+          body: "${{ steps.mutate.outputs.stdout }}"
+          committer: GitHub <noreply@github.com>
+          author: GitHub <noreply@github.com>

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Nova
 .nova
+
+new_blogs.json
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem "rake"
 gem "json"
 gem "json-schema"
+gem 'rubocop', group: 'development'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,32 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    parallel (1.22.1)
+    parser (3.1.3.0)
+      ast (~> 2.4.1)
     public_suffix (4.0.6)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.6.1)
+    rexml (3.2.5)
+    rubocop (1.41.1)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.23.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.24.1)
+      parser (>= 3.1.1.0)
+    ruby-progressbar (1.11.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby
@@ -16,6 +37,7 @@ DEPENDENCIES
   json
   json-schema
   rake
+  rubocop
 
 BUNDLED WITH
    2.3.3

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,52 @@
-require "json"
-require "json-schema"
+require 'json'
+require 'json-schema'
+require 'net/https'
 
-task default: "validate:json"
+task default: 'validate:json'
 
 namespace :validate do
-  desc "Validate the JSON schema and the blogs JSON content"
+  desc 'Validate the JSON schema and the blogs JSON content'
   task :json do
-    JSON::Validator.validate!("schema_blogs.json", "blogs.json")
+    JSON::Validator.validate!('schema_blogs.json', 'blogs.json')
+  end
+
+  task :urls do
+    file = File.read('blogs.json')
+    data = JSON.parse(file)
+    data.each do |language|
+      language['categories'].each do |category|
+        category['sites'].each do |site|
+          %w[site_url feed_url].each do |field|
+            begin
+              res = Net::HTTP.get_response(URI(site[field]))
+
+              if res.code.to_i == 301 || res.code.to_i == 302
+                puts "#{site['title']} returns a #{res.code} for #{field} (#{site[field]})"
+                if !res['location'].start_with?('http://') && !res['location'].start_with?('https://')
+                  puts "Redirect is not a valid URL (#{res['location']}), skipping"
+                  puts
+                  next
+                end
+
+                site[field] = res['location']
+                puts "Updating #{field} to #{site[field]}"
+                puts
+              elsif res.code.to_i >= 400
+                # NO OP
+                # puts "#{site['title']} returns a #{res.code} for #{field} (#{site[field]})"
+                # puts
+              end
+            rescue
+              # NO OP
+              # puts "#{site['title']} is unable to connect for #{field} (#{site[field]})"
+              # puts
+            end
+          end
+        end
+      end
+    end
+    File.open('new_blogs.json', 'w') do |f|
+      f.write(JSON.pretty_generate(data))
+    end
   end
 end


### PR DESCRIPTION
Every Tuesday morning, a Github action will run and check every `site_url` and `feed_url` for a redirect. If it is a 301 or 302, a PR will be opened to update the URL to whatever the redirect is.

Future work could include 4xx errors but a more thought-out solution is required to address those.

Example PR: https://github.com/rcobelli/iOSDevDirectory/pull/14 (this one is very long but they should shrink dramatically after the first batch).
