### PR TITLE
Add Brad Root's blog (iOS FOSS developer)

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -740,6 +740,12 @@
             "feed_url": "https://bootstragram.com/feed/by_tag/ios.xml"
           },
           {
+            "title": "Brad Root’s Blog",
+            "author": "Brad Root",
+            "site_url": "https://amiantos.net/tags/programming/",
+            "feed_url": "https://amiantos.net/tags/programming/feed/"
+          },
+          {
             "title": "Bret Victor’s Blog",
             "author": "Bret Victor",
             "site_url": "http://worrydream.com/",


### PR DESCRIPTION
- adding my blog back (it was removed sometime between now and 2019, not sure why), scoped this time to my programming category