### PR TITLE
Update Runway Team's X (Twitter) handle

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5557,7 +5557,7 @@
             "author": "The Runway Team",
             "site_url": "https://www.runway.team/blog",
             "feed_url": "https://www.runway.team/blog/rss.xml",
-            "twitter_url": "https://twitter.com/RunwayTeam_"
+            "twitter_url": "https://twitter.com/RunwayTeam"
           },
           {
             "title": "SHAPE Code Blog",


### PR DESCRIPTION
We semi-recently secured a handle closer to our company name (sans the underscore) so we'd like to account for this change