### PR TITLE
[chore] remove inaccessible blog code block.

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -6853,12 +6853,6 @@
             "twitter_url": "http://twitter.com/_jooheekim_"
           },
           {
-            "title": "NSHipster 한국",
-            "author": "NSHipster",
-            "site_url": "https://nshipster.co.kr",
-            "feed_url": "https://nshipster.co.kr/feed.xml"
-          },
-          {
             "title": "tucan’s blog",
             "author": "tucan.dev",
             "site_url": "https://blog.canapio.com/",


### PR DESCRIPTION
- Delete the code block from the blog named ’NSHipster 한국’ which is not accessible

Modified: blogs.json