### PR TITLE
Removed Yagom’s newsletter

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -6912,18 +6912,6 @@
             "feed_url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCutO2H_AVmWHbzvE92rpxjA"
           }
         ]
-      },
-      {
-        "title": "Newsletters",
-        "slug": "newsletters",
-        "description": "Swift 또는 Apple 플랫폼 개발을 다루는 뉴스레터 또는 라운드업 블로그.",
-        "sites": [
-          {
-            "title": "야아한잔",
-            "author": "Yagom",
-            "site_url": "https://page.stibee.com/subscriptions/181267"
-          }
-        ]
       }
     ]
   },


### PR DESCRIPTION
Removing this as it does not have a `feed_url`, which is a required field. I merged it as I thought it was just an extra comma in the JSON, as the last couple of PRs have had that, but I missed that this site was missing a `feed_url`.

I'd be happy to add it back if they have an RSS feed.

/cc @devKobe24 