### PR TITLE
Update feed_url for kunat.dev

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -630,7 +630,7 @@
             "title": "Bartosz Kunat’s Blog",
             "author": "Bartosz Kunat",
             "site_url": "https://kunat.dev/notes/",
-            "feed_url": "https://kunat.dev/index.xml"
+            "feed_url": "https://kunat.dev/tags/ios/index.xml"
           },
           {
             "title": "Bartosz Polaczyk on Medium",


### PR DESCRIPTION
I've updated the RSS feed for my site to list only posts with the "iOS" tag.