### PR TITLE
Add Studiolanes blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4149,7 +4149,7 @@
             "title": "Studiolanes Blog - Apple Vision Pro",
             "author": "Studiolanes",
             "site_url": "https://blog.studiolanes.com/spatial",
-            "feed_url": "https://blog.studiolanes.com/feed.xml",
+            "feed_url": "https://blog.studiolanes.com/rss.xml",
             "twitter_url": "https://twitter.com/studiolanes"
           },
           {

--- a/blogs.json
+++ b/blogs.json
@@ -4146,6 +4146,13 @@
             "mastodon_url": "https://aus.social/@stuart"
           },
           {
+            "title": "Studiolanes Blog - Apple Vision Pro",
+            "author": "Studiolanes",
+            "site_url": "https://blog.studiolanes.com/spatial",
+            "feed_url": "https://blog.studiolanes.com/feed.xml",
+            "twitter_url": "https://twitter.com/studiolanes"
+          },
+          {
             "title": "Sunset Lake Software",
             "author": "Brad Larson",
             "site_url": "http://www.sunsetlakesoftware.com/blog/index.html",


### PR DESCRIPTION
Adding a new blog named Studiolanes. The blog covers various topics including but not limited to the Apple Vision Pro. Here is one of our most recent posts for reference.

https://blog.studiolanes.com/posts/2d-to-spatial-photos