### PR TITLE
Add twocentstudios to development blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4767,6 +4767,14 @@
             "twitter_url": "https://twitter.com/TyHnec"
           },
           {
+            "title": "twocentstudios",
+            "author": "Chris Trott",
+            "site_url": "https://twocentstudios.com/blog/tags/apple/index.html",
+            "feed_url": "https://twocentstudios.com/blog/tags/apple/feed.xml",
+            "twitter_url": "https://twitter.com/twocentstudios",
+            "mastodon_url": "https://hackyderm.io/@twocentstudios"
+          },
+          {
             "title": "Two Minute iOS",
             "author": "Damien Laughton",
             "site_url": "https://medium.com/@dfplaughton",


### PR DESCRIPTION
Hi, I'd like to add my long-standing blog to the list. 

Most of my posts are iOS-related, but I've added an `apple` tag to make sure it's 100%. 

Thanks in advance 🙏 