### PR TITLE
Add Zühlke Software Engineering Corner

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -87,12 +87,6 @@
         "description": "No matter if it covers Swift or Objective-C, whether it’s focused on app architecture or UI coding. As long as it’s related to Apple platform development then it belongs here.",
         "sites": [
           {
-            "title": "Software Engineering Corner",
-            "author": "Zühlke engineers",
-            "site_url": "https://software-engineering-corner.zuehlke.com/tag/ios",
-            "feed_url": "https://software-engineering-corner.zuehlke.com/rss.xml"
-          },
-          {
             "title": "/var/log/journal",
             "author": "Gaël Foppolo",
             "site_url": "https://gaelfoppolo.com/",
@@ -5360,6 +5354,12 @@
         "slug": "companies",
         "description": "If a blog is published by a company rather than an individual (or group of individuals), but is still related to Apple platform development. This is where you’ll find it!",
         "sites": [
+          {
+            "title": "Software Engineering Corner",
+            "author": "Zühlke engineers",
+            "site_url": "https://software-engineering-corner.zuehlke.com/tag/ios",
+            "feed_url": "https://software-engineering-corner.zuehlke.com/rss.xml"
+          },
           {
             "title": "all about apps",
             "author": "all about apps Team",

--- a/blogs.json
+++ b/blogs.json
@@ -87,6 +87,12 @@
         "description": "No matter if it covers Swift or Objective-C, whether it’s focused on app architecture or UI coding. As long as it’s related to Apple platform development then it belongs here.",
         "sites": [
           {
+            "title": "Software Engineering Corner",
+            "author": "Zühlke engineers",
+            "site_url": "https://software-engineering-corner.zuehlke.com/tag/ios",
+            "feed_url": "https://software-engineering-corner.zuehlke.com/rss.xml"
+          },
+          {
             "title": "/var/log/journal",
             "author": "Gaël Foppolo",
             "site_url": "https://gaelfoppolo.com/",


### PR DESCRIPTION
This is a general company engineering blog.

I didn't find a way to create an RSS feed in Hashnode for a specific tag/category. Any experience with that? 

Thanks in advance :)