### PR TITLE
Added ThinkPractice Swift RSS url

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5786,6 +5786,13 @@
             "twitter_url": "https://twitter.com/cirrus_labs"
           },
           {
+            "title": "ThinkPractice Swift Posts",
+            "author": "Tim De Jong",
+            "site_url": "https://www.thinkpractice.nl/tags/swift/",
+            "feed_url": "https://www.thinkpractice.nl/tags/swift/index.xml",
+            "mastodon_url": "https://mastodon.social/@tjadejong"
+          },
+          {
             "title": "thoughtbot: iOS posts",
             "author": "thoughtbot Team",
             "site_url": "https://thoughtbot.com/blog/tags/ios",


### PR DESCRIPTION
Hi I've added my new blog's swift category url and rss link to the directory. I'm an individual but I'm posting under my companies name. Hope it is alright like that and looking forward to being added to the index!
