### PR TITLE
Update RSS Feed URL for Cyndi Chin's blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1124,7 +1124,7 @@
             "title": "Cyndi Chin's Blog",
             "author": "Cyndi Chin",
             "site_url": "https://cyndichin.github.io/blog/",
-            "feed_url": "https://cyndichin.github.io/blog/feed.xml"
+            "feed_url": "https://cyndichin.github.io/feed.xml"
           },
           {
             "title": "César Vargas on Medium",


### PR DESCRIPTION
The feed url on the iodevdirectory was going to a 404, updated the JSON to have the proper link: `https://cyndichin.github.io/feed.xml`. 

Thank you to [Patrick Biedrzycki](https://www.linkedin.com/in/patrk/) for reaching out to let me know. ❤️ 