### PR TITLE
Update Mihaela MJ's Blog entry

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2882,10 +2882,14 @@
           },
           {
             "title": "Mihaela MJ's Blog",
-            "author": "Mihaela MJ",
+            "author": "Mihaela Mihaljević Jakić",
             "site_url": "https://aleahim.com",
             "feed_url": "https://aleahim.com/rss.xml",
-            "x_url": "https://x.com/civeljahim"
+            "x_url": "https://x.com/diyamantina",
+            "bluesky_url": "https://bsky.app/profile/dijamantina.bsky.social",
+            "mastodon_url": "https://mastodon.social/@ameahim",
+            "github_url": "https://github.com/mihaelamj",
+            "linkedin_url": "https://www.linkedin.com/in/mihaelamj/"
           },
           {
             "title": "Mike Mikina’s Blog",


### PR DESCRIPTION
Updates my existing entry under **English Language > Development Blogs**.

Changes:
- Author field: `Mihaela MJ` → `Mihaela Mihaljević Jakić` (full name).
- X handle: `@civeljahim` (retired) → `@diyamantina` (current).
- Added Bluesky, Mastodon, GitHub, and LinkedIn URLs.

The blog now also publishes a full-text RSS feed (post bodies in `<content:encoded>`), so downstream full-text search tools can index the content properly.