### PR TITLE
Update social media link for Igor Kulman's blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -1942,7 +1942,7 @@
             "author": "Igor Kulman",
             "site_url": "https://blog.kulman.sk",
             "feed_url": "https://blog.kulman.sk/index.xml",
-            "x_url": "https://x.com/igorkulman"
+            "mastodon_url": "https://hachyderm.io/@igorkulman"
           },
           {
             "title": "iJoshSmith",


### PR DESCRIPTION
Replaced x_url with mastodon_url for Igor Kulman's blog.