### PR TITLE
Add RocketSim Blog

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3693,6 +3693,15 @@
             "feed_url": "https://rwapp.co.uk/feed.rss"
           },
           {
+            "title": "RocketSim Blog",
+            "author": "Antoine van der Lee",
+            "site_url": "https://www.rocketsim.app/blog/",
+            "feed_url": "https://www.rocketsim.app/rss.xml",
+            "github_url": "https://github.com/AvdLee/RocketSimApp",
+            "linkedin_url": "https://linkedin.com/company/rocketsim",
+            "x_url": "https://x.com/rocketsim_app"
+          },
+          {
             "title": "Rod Schmidt: Thoughts on Software Development",
             "author": "Rod Schmidt",
             "site_url": "https://rodschmidt.com/",

--- a/blogs.json
+++ b/blogs.json
@@ -3693,15 +3693,6 @@
             "feed_url": "https://rwapp.co.uk/feed.rss"
           },
           {
-            "title": "RocketSim Blog",
-            "author": "Antoine van der Lee",
-            "site_url": "https://www.rocketsim.app/blog/",
-            "feed_url": "https://www.rocketsim.app/rss.xml",
-            "github_url": "https://github.com/AvdLee/RocketSimApp",
-            "linkedin_url": "https://linkedin.com/company/rocketsim",
-            "x_url": "https://x.com/rocketsim_app"
-          },
-          {
             "title": "Rod Schmidt: Thoughts on Software Development",
             "author": "Rod Schmidt",
             "site_url": "https://rodschmidt.com/",
@@ -5523,6 +5514,15 @@
             "site_url": "https://roadfiresoftware.com/blog/",
             "feed_url": "https://roadfiresoftware.com/feed/",
             "x_url": "https://x.com/jtbrown"
+          },
+          {
+            "title": "RocketSim Blog",
+            "author": "Antoine van der Lee",
+            "site_url": "https://www.rocketsim.app/blog/",
+            "feed_url": "https://www.rocketsim.app/rss.xml",
+            "github_url": "https://github.com/AvdLee/RocketSimApp",
+            "linkedin_url": "https://linkedin.com/company/rocketsim",
+            "x_url": "https://x.com/rocketsim_app"
           },
           {
             "title": "Rosberry Blog",


### PR DESCRIPTION
## Summary
- Adds RocketSim Blog to the English Development Blogs category.
- Includes the newly published RSS feed at `https://www.rocketsim.app/rss.xml`.

## Validation
- Verified `https://www.rocketsim.app/rss.xml` returns `200` with `application/xml` and RocketSim blog entries.
- `python3 -m json.tool blogs.json >/dev/null`
- Validated `blogs.json` against the same required fields, allowed fields, and URI constraints from `schema_blogs.json` with a local Python script.

Note: `bundle exec rake validate:json` could not run locally because `.ruby-version` requests Ruby 4.0.1, which is not installed on my machine.