### PR TITLE
Adds Helm for App Store Connect blog to the directory

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5665,6 +5665,12 @@
             "author": "Babs",
             "site_url": "https://verycuriousengineer.substack.com",
             "feed_url": "https://verycuriousengineer.substack.com/feed"
+          },
+          {
+            "title": "Helm for App Store Connect",
+            "author": "Anima Software",
+            "site_url": "https://helm-app.com/changelog",
+            "feed_url": "https://helm-app.com/changelog/rss.xml"
           }
         ]
       },


### PR DESCRIPTION
We would like to add our blog to the directory now that we are creating more content and that we've added an RSS feed.