### PR TITLE
Add Chukaufo's Blog to blogs.json

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -972,6 +972,14 @@
             "x_url": "https://x.com/ctietze"
           },
           {
+            "title": "Chukaufo's Blog",
+            "author": "Chuka Uwefoh",
+            "site_url": "https://blog.chukaufo.xyz/",
+            "feed_url": "https://blog.chukaufo.xyz/feed.xml",
+            "github_url": "https://github.com/chukaufo",
+            "linkedin_url": "https://linkedin.com/in/chuka-uwefoh-6183b3277"
+          },
+          {
             "title": "Coach Frank",
             "author": "Frank Courville",
             "site_url": "http://ioscoachfrank.com/",


### PR DESCRIPTION
Adds my blog (blog.chukaufo.xyz) to the development category.

I write about iOS/Swift development, including a recent post on building a zero-backend finance tracker using Core Data, CloudKit, and Vision OCR.