### PR TITLE
Add Inscribe Blog to English company blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5409,6 +5409,12 @@
             "feed_url": "https://medium.com/feed/@igornemenonok"
           },
           {
+            "title": "Inscribe Blog",
+            "author": "Josip Markovic",
+            "site_url": "https://get-inscribe.com/blog.html",
+            "feed_url": "https://get-inscribe.com/feed.xml"
+          },
+          {
             "title": "Inside PSPDFKit",
             "author": "PSPDFKit Team",
             "site_url": "https://www.nutrient.io/blog/",


### PR DESCRIPTION
Adding the Inscribe blog (get-inscribe.com) under Company Blogs.

Inscribe is a private, on-device transcription and document AI app for iPhone/iPad/Mac. The blog covers Apple platform speech/AI topics; the current lead article is an original benchmark of Apple's new SpeechAnalyzer API vs SFSpeechRecognizer and Whisper on LibriSpeech, with the raw per-utterance data published for rescoring: https://get-inscribe.com/blog/apple-speech-api-benchmark.html

Entry is inserted in alphabetical order (The-stripped) and the feed validates:
- site: https://get-inscribe.com/blog.html
- feed: https://get-inscribe.com/feed.xml