### PR TITLE
Add bitdrift blog to company blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -5184,9 +5184,9 @@
           },
           {
             "title": "bitdrift's mobile observability blog",
-            "author": "Pete Morelli, Matt Klein, Collin Anderson, Iain Finlayson",
+            "author": "bitdrift Team",
             "site_url": "https://blog.bitdrift.io/",
-            "feed_url": "https://blog.bitdrift.io/feed/full.xml",
+            "feed_url": "https://blog.bitdrift.io/feed.xml",
             "bluesky_url": "https://bsky.app/profile/bitdrift.io",
             "mastodon_url": "https://social.bitdrift.io/@bitdrift",
             "x_url": "https://x.com/bitdriftio",

--- a/blogs.json
+++ b/blogs.json
@@ -5183,6 +5183,17 @@
             "x_url": "https://x.com/bitrise"
           },
           {
+            "title": "bitdrift's mobile observability blog",
+            "author": "Pete Morelli, Matt Klein, Collin Anderson, Iain Finlayson",
+            "site_url": "https://blog.bitdrift.io/",
+            "feed_url": "https://blog.bitdrift.io/feed/full.xml",
+            "bluesky_url": "https://bsky.app/profile/bitdrift.io",
+            "mastodon_url": "https://social.bitdrift.io/@bitdrift",
+            "x_url": "https://x.com/bitdriftio",
+            "github_url": "https://github.com/bitdriftlabs",
+            "linkedin_url": "https://www.linkedin.com/company/bitdrift/"
+          },
+          {
             "title": "Blueground's Engineering Blog",
             "author": "iOS Engineers @ Blueground",
             "site_url": "https://engineering.theblueground.com/",


### PR DESCRIPTION
## Summary

- Adds bitdrift's mobile observability blog to the English Company Blogs category.
- Includes the blog feed and public social/profile links.

## Validation

- Verified `blogs.json` parses successfully.
- Verified `https://blog.bitdrift.io/feed/full.xml` returns `200` with `application/xml`.