### PR TITLE
Add Reza Bina

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3699,6 +3699,14 @@
             "x_url": "https://x.com/revoreva"
           },
           {
+            "title": "Reza Bina",
+            "author": "Reza Bina",
+            "site_url": "https://reza-bina.com",
+            "feed_url": "https://reza-bina.com/rss.xml",
+            "github_url": "https://github.com/rezabina86",
+            "linkedin_url": "https://www.linkedin.com/in/reza-bina/"
+          },
+          {
             "title": "Rhonabwy",
             "author": "Joseph Heck",
             "site_url": "https://rhonabwy.com/",


### PR DESCRIPTION
Reza Bina is an iOS engineer in Berlin writing about Swift concurrency, on-device ML, and privacy-first iOS development. Feed URL: https://reza-bina.com/rss.xml