### PR TITLE
Add Nexus Shell Engineering

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -3168,6 +3168,12 @@
             "mastodon_url": "https://mastodon.social/@neilgmacy"
           },
           {
+            "title": "Nexus Shell Engineering",
+            "author": "Sameral",
+            "site_url": "https://nexusshell.hashnode.dev/",
+            "feed_url": "https://nexusshell.hashnode.dev/rss.xml"
+          },
+          {
             "title": "Niamh Power on Medium",
             "author": "Niamh Power",
             "site_url": "https://medium.com/@niamhpower",

--- a/blogs.json
+++ b/blogs.json
@@ -3168,12 +3168,6 @@
             "mastodon_url": "https://mastodon.social/@neilgmacy"
           },
           {
-            "title": "Nexus Shell Engineering",
-            "author": "Sameral",
-            "site_url": "https://nexusshell.hashnode.dev/",
-            "feed_url": "https://nexusshell.hashnode.dev/rss.xml"
-          },
-          {
             "title": "Niamh Power on Medium",
             "author": "Niamh Power",
             "site_url": "https://medium.com/@niamhpower",
@@ -5517,6 +5511,12 @@
             "site_url": "https://www.netguru.com/blog/topic/ios",
             "feed_url": "https://www.netguru.com/blog/topic/ios/rss.xml",
             "x_url": "https://x.com/netguru"
+          },
+          {
+            "title": "Nexus Shell Engineering",
+            "author": "Sameral",
+            "site_url": "https://nexusshell.hashnode.dev/",
+            "feed_url": "https://nexusshell.hashnode.dev/rss.xml"
           },
           {
             "title": "Novoda Blog",


### PR DESCRIPTION
Adds Nexus Shell Engineering to the English Development Blogs section.

The blog covers implementation lessons from a native SwiftUI macOS SSH client. Its first article discusses bounded libssh2 draining, frame-level UI batching, UTF-8 integrity, and binary transfer separation in a WebKit-backed terminal.

- Site: https://nexusshell.hashnode.dev/
- RSS: https://nexusshell.hashnode.dev/rss.xml
- Example article: https://nexusshell.hashnode.dev/keeping-a-macos-terminal-ui-responsive-during-large-ssh-output-bursts

Disclosure: I develop Nexus Shell and maintain this engineering blog. This small directory change was prepared with OpenAI Codex assistance and reviewed against the contribution guide.