### PR TITLE
Add McMizzle

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2902,6 +2902,13 @@
             "x_url": "https://x.com/atimca"
           },
           {
+            "title": "McMizzle",
+            "author": "Kevin McMahon",
+            "site_url": "https://mcmizzle.com/blog/",
+            "feed_url": "https://mcmizzle.com/blog/feed.xml",
+            "github_url": "https://github.com/mcmizzle"
+          },
+          {
             "title": "Megi Sila on Medium",
             "author": "Megi Sila",
             "site_url": "https://medium.com/@meggsila",


### PR DESCRIPTION
Adding my blog to the Development category.

**Site:** https://mcmizzle.com/blog/
**Feed:** https://mcmizzle.com/blog/feed.xml

Write-ups from building tvOS and iOS apps — mostly undocumented platform behaviour where the symptom pointed somewhere other than the cause. The two posts up now are a tvOS Top Shelf render cache that survives an uninstall, and HealthKit reads failing silently to zero while the device is locked.

Inserted alphabetically in `development`, between *Maxim Smirnov on Medium* and *Megi Sila on Medium*. Diff is the seven added lines and nothing else — I matched the file's existing indentation and its lack of a trailing newline. Verified `blogs.json` still parses and all three URLs return 200.

Worth flagging honestly: it's a new blog with two posts. If you'd rather wait for more of a track record, no complaints at all — happy to resubmit later.