### PR TITLE
Add Mechanical Turk to Development Blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -2909,6 +2909,13 @@
             "github_url": "https://github.com/mcmizzle"
           },
           {
+            "title": "Mechanical Turk",
+            "author": "Trevor Turk",
+            "site_url": "https://trevorturk.github.io",
+            "feed_url": "https://trevorturk.github.io/feed/by_tag/ios.xml",
+            "github_url": "https://github.com/trevorturk"
+          },
+          {
             "title": "Megi Sila on Medium",
             "author": "Megi Sila",
             "site_url": "https://medium.com/@meggsila",


### PR DESCRIPTION
Adding [Mechanical Turk](https://trevorturk.github.io), Trevor Turk's engineering blog documenting patterns from the [Hello Weather](https://helloweather.com) apps, to the Development Blogs category.

The blog covers multiple topics (iOS, web, AI-assisted development workflows), so per the contributing guidelines this entry uses a filtered feed of only the Apple-platform posts (SwiftUI, watchOS, StoreKit 2, APNs, Swift Testing): https://trevorturk.github.io/feed/by_tag/ios.xml