### PR TITLE
Add Vision Engineer to Development Blogs

### DIFF
--- a/blogs.json
+++ b/blogs.json
@@ -4701,6 +4701,15 @@
             "x_url": "https://x.com/johnbrayton"
           },
           {
+            "title": "Vision Engineer",
+            "author": "Tony Morales",
+            "site_url": "https://vision.engineer/",
+            "feed_url": "https://vision.engineer/feed.rss",
+            "bluesky_url": "https://bsky.app/profile/vision.engineer",
+            "github_url": "https://github.com/robomex",
+            "linkedin_url": "https://www.linkedin.com/in/atmorales0/"
+          },
+          {
             "title": "Vlad Butko's Blog",
             "author": "Vlad Butko",
             "site_url": "https://www.vbutko.com",


### PR DESCRIPTION
 Adding Vision Engineer (https://vision.engineer/), my blog on computer vision, AR, and spatial AI for Apple platforms, to the English Development Blogs category.

Site: https://vision.engineer/ 
Feed: https://vision.engineer/feed.rss

Inserted alphabetically between Virtual Sanity and Vlad Butko's Blog. Verified blogs.json parses and validates against schema_blogs.json, and both URLs return 200 with no redirects.

Disclosure: this is my own blog.